### PR TITLE
feat: change egg-docs.implements.io to eggjs.app

### DIFF
--- a/app/actions/replySiteBlock.js
+++ b/app/actions/replySiteBlock.js
@@ -27,7 +27,7 @@ function containsSiteBlock(title) {
 function replySiteBlock(on) {
   on('issues_opened', async ({ payload }) => {
     if (containsSiteBlock(payload.issue.title)) {
-      const content = '由于某些众所周知的原因无法访问，建议翻墙或访问[国内镜像站点](https://egg-docs.implements.io)。';
+      const content = '由于某些众所周知的原因无法访问，建议翻墙或访问[国内镜像站点](https://eggjs.app)。';
 
       commentIssue({
         owner: payload.repository.owner.login,


### PR DESCRIPTION
Because https://egg-docs.implements.io certificate expired, so we need to change mirror site to https://eggjs.app